### PR TITLE
Enable pickling and copying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 # python build files
 build/
 sib.egg-info/
+
+.eggs

--- a/bp.cpp
+++ b/bp.cpp
@@ -123,8 +123,8 @@ void FactorGraph::append_contact(int i, int j, times_t t, real_t lambdaij, real_
 {
 	if (i == j)
 		throw invalid_argument("self loops are not allowed");
-        add_node(i);
-        add_node(j);
+    add_node(i);
+    add_node(j);
 	Node & fi = nodes[i];
 	Node & fj = nodes[j];
 	int qi = fi.times.size();
@@ -144,12 +144,14 @@ void FactorGraph::append_contact(int i, int j, times_t t, real_t lambdaij, real_
 	Neigh & ni = fi.neighs[ki];
 	Neigh & nj = fj.neighs[kj];
 	if (fi.times[qi - 2] < t) {
+		//extend fi
 		fi.push_back_time(t);
-                ++qi;
+        ++qi;
 	}
 	if (fj.times[qj - 2] < t) {
+		//extend fj
 		fj.push_back_time(t);
-                ++qj;
+        ++qj;
 	}
 	if (ni.t.size() < 2 || ni.t[ni.t.size() - 2] < qi - 2) {
 		ni.t.back() = qi - 2;
@@ -160,8 +162,8 @@ void FactorGraph::append_contact(int i, int j, times_t t, real_t lambdaij, real_
 			ni.lambdas.back() = lambdaij;
 		if (lambdaji != DO_NOT_OVERWRITE)
 			nj.lambdas.back() = lambdaji;
-                ni.lambdas.push_back(0.0);
-                nj.lambdas.push_back(0.0);
+    	ni.lambdas.push_back(0.0);
+        nj.lambdas.push_back(0.0);
 		++ni.msg;
 		++nj.msg;
 	} else if (ni.t[ni.t.size() - 2] == qi - 2) {
@@ -172,12 +174,12 @@ void FactorGraph::append_contact(int i, int j, times_t t, real_t lambdaij, real_
 	} else {
 		throw invalid_argument("time of contacts should be ordered");
 	}
-        // adjust infinite times
-        for (int k = 0; k < int(fi.neighs.size()); ++k) {
-                fi.neighs[k].t.back() = qi - 1;
+    // adjust infinite times
+	for (int k = 0; k < int(fi.neighs.size()); ++k) {
+			fi.neighs[k].t.back() = qi - 1;
 	}
-        for (int k = 0; k < int(fj.neighs.size()); ++k) {
-                fj.neighs[k].t.back() = qj - 1;
+	for (int k = 0; k < int(fj.neighs.size()); ++k) {
+			fj.neighs[k].t.back() = qj - 1;
 	}
 }
 

--- a/bp.h
+++ b/bp.h
@@ -70,10 +70,10 @@ struct Node {
 	void push_back_time(times_t t) {
 		times.back() = t;
 		times.push_back(Tinf);
-                ht.push_back(ht.back());
-                hg.push_back(hg.back());
-                bt.push_back(bt.back());
-                bg.push_back(bg.back());
+		ht.push_back(ht.back());
+		hg.push_back(hg.back());
+		bt.push_back(bt.back());
+		bg.push_back(bg.back());
 	}
 	std::shared_ptr<Proba> prob_i;
 	std::shared_ptr<Proba> prob_r;

--- a/pysib.cpp
+++ b/pysib.cpp
@@ -212,7 +212,15 @@ PYBIND11_MODULE(_sib, m) {
         .def_readwrite("psus", &Params::psus)
         .def_readwrite("pautoinf", &Params::pautoinf)
         .def_readwrite("learn_rate", &Params::learn_rate)
-        .def("__repr__", &lexical_cast<string, Params>);
+        .def("__repr__", &lexical_cast<string, Params>)
+        .def("__copy__", [](const Params &s){
+            return Params(s); 
+        })
+        .def("__deepcopy__", [](const Params &s, py::dict){
+            return Params(s); 
+        }, "memo"_a);
+
+        ;
 
     py::class_<FactorGraph>(m, "FactorGraph", "SIB class representing the graphical model of the epidemics")
         .def(py::init<Params const &,

--- a/pysib.cpp
+++ b/pysib.cpp
@@ -27,7 +27,7 @@ namespace py = pybind11;
 using namespace std;
 using boost::lexical_cast;
 
-
+using namespace pybind11::literals;
 
 
 
@@ -155,7 +155,7 @@ PYBIND11_MODULE(_sib, m) {
             [](const Test &t){ //__getstate__
                 return py::make_tuple(t.ps, t.pi, t.pr);
             },
-            [](py::tuple p){ //__set_state__
+            [](py::tuple p){ //__setstate__
                 if (p.size()!=3)
                     throw std::runtime_error("Invalid pickling state!");
                 Test test = Test(p[0].cast<real_t>(), p[1].cast<real_t>(),
@@ -230,7 +230,7 @@ PYBIND11_MODULE(_sib, m) {
         })
         .def("__deepcopy__", [](const Params &s, py::dict){
             return Params(s); 
-        }, "memo");
+        }, "memo"_a);
 
     py::class_<FactorGraph>(m, "FactorGraph", "SIB class representing the graphical model of the epidemics")
         .def(py::init<Params const &,
@@ -289,7 +289,7 @@ PYBIND11_MODULE(_sib, m) {
         })
         .def("__deepcopy__", [](const FactorGraph &s, py::dict){
             return FactorGraph(s); 
-        }, "memo");
+        }, "memo"_a);
 
     py::class_<Node>(m, "Node", "SIB class representing an individual")
         .def("marginal", &get_marginal, "compute marginal probabilities (pS,pI,pR) corresponding to times n.times[1:]")

--- a/pysib.cpp
+++ b/pysib.cpp
@@ -150,7 +150,19 @@ PYBIND11_MODULE(_sib, m) {
         .def("__repr__", &lexical_cast<string, Test>)
         .def_readwrite("ps", &Test::ps, "probability of S")
         .def_readwrite("pi", &Test::pi, "probability of I")
-        .def_readwrite("pr", &Test::pr, "probability of R");
+        .def_readwrite("pr", &Test::pr, "probability of R")
+        .def(py::pickle(
+            [](const Test &t){ //__getstate__
+                return py::make_tuple(t.ps, t.pi, t.pr);
+            },
+            [](py::tuple p){ //__set_state__
+                if (p.size()!=3)
+                    throw std::runtime_error("Invalid pickling state!");
+                Test test = Test(p[0].cast<real_t>(), p[1].cast<real_t>(),
+                    p[2].cast<real_t>());
+                return test;
+            }
+        ));
 
     py::class_<Proba, shared_ptr<Proba>>(m, "Proba")
         .def("__call__", [](Proba const & p, real_t d) { return p(d); } )

--- a/pysib.cpp
+++ b/pysib.cpp
@@ -218,7 +218,7 @@ PYBIND11_MODULE(_sib, m) {
         })
         .def("__deepcopy__", [](const Params &s, py::dict){
             return Params(s); 
-        }, "memo"_a);
+        }, "memo");
 
         ;
 

--- a/pysib.cpp
+++ b/pysib.cpp
@@ -220,8 +220,6 @@ PYBIND11_MODULE(_sib, m) {
             return Params(s); 
         }, "memo");
 
-        ;
-
     py::class_<FactorGraph>(m, "FactorGraph", "SIB class representing the graphical model of the epidemics")
         .def(py::init<Params const &,
                 vector<tuple<int,int,times_t,real_t>>,
@@ -273,7 +271,13 @@ PYBIND11_MODULE(_sib, m) {
 
         .def("showmsg", [](FactorGraph & f){f.show_msg(std::cout);}, "show messages for debugging")
         .def_readonly("nodes", &FactorGraph::nodes, "all nodes in this FactorGraph")
-        .def_readonly("params", &FactorGraph::params, "parameters");
+        .def_readonly("params", &FactorGraph::params, "parameters")
+        .def("__copy__", [](const FactorGraph &s){
+            return FactorGraph(s); 
+        })
+        .def("__deepcopy__", [](const FactorGraph &s, py::dict){
+            return FactorGraph(s); 
+        }, "memo");
 
     py::class_<Node>(m, "Node", "SIB class representing an individual")
         .def("marginal", &get_marginal, "compute marginal probabilities (pS,pI,pR) corresponding to times n.times[1:]")

--- a/test/copy.doctest
+++ b/test/copy.doctest
@@ -1,0 +1,21 @@
+>>> import sib
+>>> import copy
+>>> 
+>>> t = sib.Test(0.1,0.6,0.3)
+>>> 
+>>> copy.copy(t)
+Test(ps=0.1, pi=0.6, pr=0.3)
+>>> memo = dict()
+>>> copy.deepcopy(t, memo)
+Test(ps=0.1, pi=0.6, pr=0.3)
+>>> 
+>>> 
+>>> par = sib.Params(prob_i=sib.Gamma(0.6,0.1),prob_r=sib.Exponential(mu=0.2),
+...     pseed=0.01,
+...     psus=0.5,
+...     pautoinf=1e-6,
+... )
+>>> copy.copy(par)
+Params(prob_i=Gamma(0.6,0.1),prob_r=Exponential(0.2),pseed=0.01,psus=0.5,pautoinf=1e-06),learn_rate=0)
+>>> copy.deepcopy(par, memo)
+Params(prob_i=Gamma(0.6,0.1),prob_r=Exponential(0.2),pseed=0.01,psus=0.5,pautoinf=1e-06),learn_rate=0)

--- a/test/copy.doctest
+++ b/test/copy.doctest
@@ -1,15 +1,13 @@
 >>> import sib
 >>> import copy
->>> 
+
 >>> t = sib.Test(0.1,0.6,0.3)
->>> 
 >>> copy.copy(t)
 Test(ps=0.1, pi=0.6, pr=0.3)
 >>> memo = dict()
 >>> copy.deepcopy(t, memo)
 Test(ps=0.1, pi=0.6, pr=0.3)
->>> 
->>> 
+
 >>> par = sib.Params(prob_i=sib.Gamma(0.6,0.1),prob_r=sib.Exponential(mu=0.2),
 ...     pseed=0.01,
 ...     psus=0.5,

--- a/test/data_load.py
+++ b/test/data_load.py
@@ -28,7 +28,7 @@ ALL_OBS_FILE= "all_obs.json.bz2"
 ALL_EPI = "all_epidemies"
 
 NAMES_COLS_CONTACTS = ["t","i","j","lambda"]
-CONTACTS_DTYPES = dict(zip(NAMES_COLS_CONTACTS,(np.int,np.int,np.int,np.float) ))
+CONTACTS_DTYPES = dict(zip(NAMES_COLS_CONTACTS,(np.int_,np.int_,np.int_,np.float_) ))
 
 
 

--- a/test/likelihood.doctest
+++ b/test/likelihood.doctest
@@ -32,3 +32,16 @@ FactorGraph
 >>> sib.iterate(f, tol=1e-15, callback=None)
 >>> f.loglikelihood()
 -9535.906070631045
+
+### test copying of FactorGraph
+>>> import copy
+>>> copy.copy(f)
+FactorGraph
+            nodes: 101
+            edges: 100 (100 asymmetric)
+    time contacts: 100
+>>> copy.deepcopy(f)
+FactorGraph
+            nodes: 101
+            edges: 100 (100 asymmetric)
+    time contacts: 100


### PR DESCRIPTION
Enables pickling of `sib.Test`, and copying of `sib.Params` and `sib.FactorGraph`. This is needed in some cases when the rankers need to be copied in-memory.

Also, align the code in some places, and add some comments.